### PR TITLE
Make the alizarin markdown demo compile and work on crystal 1.0.0

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -7,7 +7,7 @@ description: |
 authors:
   - TheEEs <visualbasic2013@hotmail.com>
 
-crystal: 0.33.0
+crystal: 1.0.0
 
 libraries:
   libwebkit2gtk: "4.0"

--- a/src/components/web_view.cr
+++ b/src/components/web_view.cr
@@ -112,7 +112,7 @@ class WebView
   # end
   # ```
   def on_close(&b : Callback)
-    @box = Box.box({self, b})
+    box = Box.box({self, b})
     LibWebKit.connect_signal @browser, "destroy", ->(data1 : Void*, data2 : Void*, data3 : Void*) {
       data = Box({WebView, Callback}).unbox(data1)
       webview = data[0]
@@ -120,7 +120,7 @@ class WebView
       webview.destroy_browser
       webview.close_ipc_socket if webview.ipc?
       callback.call webview
-    }, @box, nil, LibWebKit::GtkGConnectFlags::All
+    }, box, nil, LibWebKit::GtkGConnectFlags::All
   end
 
   # :nodoc:
@@ -228,7 +228,7 @@ class WebView
         res = LibWebKit.script_finish_result object, result, nil
         if res.null?
           puts "JavaScript execution has cause error(s)".colorize(:red).on(:black)
-          return
+          next
         end
         jsc_value = LibWebKit.get_jsc_from_js_result res
         webview = Box(WebView).unbox(user_data)
@@ -253,7 +253,7 @@ class WebView
         res = LibWebKit.script_finish_result object, result, nil
         if res.null?
           puts "JavaScript execution has cause error(s)".colorize(:red).on(:black)
-          return
+          next
         end
         jsc_value = LibWebKit.get_jsc_from_js_result res
         data = Box(JSC::JSValue -> Nil).unbox(user_data)


### PR DESCRIPTION
This PR does not fix all issues with crystal 1.0.0, but at least makes it compile and work again.
The specs do not finish currently, showing the error "ReferenceError: Can't find variable: writeHTMLBodyToFile" when running the command `eval_js "writeHTMLBodyToFile('#{path}')"`.
When using the browser, it can also crash randomly, but I don't know if it's alizarin's fault.