### PR TITLE
:memo: Fix example code

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,13 +39,13 @@ require "alizarin"
 
   webview = WebView.new 
 
-  webview.on_close |webview|
+  webview.on_close do |webview|
     puts "#{webview} is going to close".colorize :green
     exit 0
   end
 
   webview.window_size 800, 600
-  webview.load_url "https://crystal-lang.org/
+  webview.load_url "https://crystal-lang.org/"
 
   webview.run
 


### PR DESCRIPTION
This commit fixes the example code on README, which currently doesn't run, by adding the `do` keyword and closing the string literal.